### PR TITLE
Config.uk: Fix dependencies with libcxxabi

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -1,5 +1,5 @@
 menuconfig LIBUNWIND
     bool "libunwind - unwinder"
 	select LIBNOLIBC if !HAVE_LIBC
-	select LIBCOMPILER_RT
+	select LIBCXXABI
     default n


### PR DESCRIPTION
`libcxxabi` and `libunwind` create circular dependencies.
Since libraries like `libcompiler-rt` and `cxx` depend on `libunwind`, it's more intuitive to remove the `libcxxabi` requirement of `libunwind` and make `libunwind` select `libcxxabi`.

`libunwind` also does not depend on `libcompiler-rt`.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>