### PR TITLE
Bump version to 16.0.3 (C++17 support)

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -1,91 +1,71 @@
 #  libunwind Makefile.uk
 #
-#  Authors: Vlad-Andrei Badoiu <vlad_andrei.badoiu@stud.acs.upb.ro>
+#  Authors: Marco Schlumpp <marco@unikraft.io>
 #
-#  Copyright (c) 2019, Politehnica University of Bucharest. All rights reserved.
+#  Copyright (c) 2023, Unikraft GmbH.
+#                All rights reserved.
 #
-#  Redistribution and use in source and binary forms, with or without
-#  modification, are permitted provided that the following conditions
-#  are met:
-#
-#  1. Redistributions of source code must retain the above copyright
-#     notice, this list of conditions and the following disclaimer.
-#  2. Redistributions in binary form must reproduce the above copyright
-#     notice, this list of conditions and the following disclaimer in the
-#     documentation and/or other materials provided with the distribution.
-#  3. Neither the name of the copyright holder nor the names of its
-#     contributors may be used to endorse or promote products derived from
-#     this software without specific prior written permission.
-#
-#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-#  POSSIBILITY OF SUCH DAMAGE.
-#
-
 
 ################################################################################
 # Library registration
 ################################################################################
 $(eval $(call addlib_s,libunwind,$(CONFIG_LIBUNWIND)))
 
-ifeq ($(CONFIG_LIBUNWIND),y)
-ifneq ($(CONFIG_LIBCOMPILER_RT),y)
-$(error Require libcompiler_rt)
-endif
-endif
-
 ################################################################################
-# Sources
+# Original sources
 ################################################################################
-LIBUNWIND_VERSION=7.0.0
-LIBUNWIND_URL=http://releases.llvm.org/$(LIBUNWIND_VERSION)/libunwind-$(LIBUNWIND_VERSION).src.tar.xz
+LIBUNWIND_VERSION=16.0.3
+LIBUNWIND_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBUNWIND_VERSION)/libunwind-$(LIBUNWIND_VERSION).src.tar.xz
 LIBUNWIND_PATCHDIR=$(LIBUNWIND_BASE)/patches
+
 $(eval $(call fetch,libunwind,$(LIBUNWIND_URL)))
 $(eval $(call patch,libunwind,$(LIBUNWIND_PATCHDIR),libunwind-$(LIBUNWIND_VERSION).src))
 
 ################################################################################
 # Helpers
 ################################################################################
-LIBUNWIND_SUBDIR=libunwind-$(LIBUNWIND_VERSION).src
-LIBUNWIND_SRC=$(LIBUNWIND_ORIGIN)/$(LIBUNWIND_SUBDIR)
+LIBUNWIND_EXTRACTED = $(LIBUNWIND_ORIGIN)/libunwind-$(LIBUNWIND_VERSION).src
 
 ################################################################################
 # Library includes
 ################################################################################
-CINCLUDES-$(CONFIG_LIBUNWIND) += -I$(LIBUNWIND_SRC)/include
-CXXINCLUDES-$(CONFIG_LIBUNWIND) += -I$(LIBUNWIND_SRC)/include
+CINCLUDES-$(CONFIG_LIBUNWIND) += -I$(LIBUNWIND_EXTRACTED)/include
+CXXINCLUDES-$(CONFIG_LIBUNWIND) += -I$(LIBUNWIND_EXTRACTED)/include
 
-LIBUNWIND_CINCLUDES-y   += -I$(LIBUNWIND_SRC)/src
-LIBUNWIND_CXXINCLUDES-y += -I$(LIBUNWIND_SRC)/src
+LIBUNWIND_COMMON_INCLUDES-y += -I$(LIBUNWIND_EXTRACTED)/include
+LIBUNWIND_COMMON_INCLUDES-y += -I$(LIBUNWIND_EXTRACTED)/src
+
+LIBUNWIND_ASINCLUDES-y = $(LIBUNWIND_COMMON_INCLUDES-y)
+LIBUNWIND_CINCLUDES-y  = $(LIBUNWIND_COMMON_INCLUDES-y)
 
 ################################################################################
 # Global flags
 ################################################################################
-CONFIG_FLAGS   += -D _LIBUNWIND_HAS_NO_THREADS  -D __ELF__  -D _LIBUNWIND_IS_NATIVE_ONLY		\
-		  -D _LIBUNWIND_SUPPORT_DWARF_UNWIND -D _LIBUNWIND_IS_BAREMETAL
+LIBUNWIND_FLAGS-y += -DNDEBUG
+LIBUNWIND_FLAGS-y += -Wall
+LIBUNWIND_FLAGS-y += -Wsign-compare
+LIBUNWIND_FLAGS-y += -D_LIBUNWIND_IS_BAREMETAL
 
-LIBUNWIND_CFLAGS-y      +=  $(CONFIG_FLAGS)
-LIBUNWIND_CXXFLAGS-y    +=  $(CONFIG_FLAGS)
+LIBUNWIND_CFLAGS-y += $(LIBUNWIND_FLAGS-y)
 
-LIBUNWIND_SUPPRESS_FLAGS += -Wno-unused-parameter -Wno-maybe-uninitialized
-LIBUNWIND_CFLAGS-y   += $(LIBUNWIND_SUPPRESS_FLAGS)
-LIBUNWIND_CXXFLAGS-y += $(LIBUNWIND_SUPPRESS_FLAGS)
+LIBUNWIND_CXXFLAGS-y += $(LIBUNWIND_FLAGS-y)
+LIBUNWIND_CXXFLAGS-y += -fno-rtti -fno-exceptions
+
+LIBUNWIND_ASFLAGS-y += -D__linux__
 
 ################################################################################
-# Library sources
+# libunwind code
 ################################################################################
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/UnwindLevel1.c
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/Unwind-sjlj.c
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/UnwindLevel1-gcc-ext.c
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/libunwind.cpp
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/Unwind-EHABI.cpp
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/UnwindRegistersRestore.S
-LIBUNWIND_SRCS-y += $(LIBUNWIND_SRC)/src/UnwindRegistersSave.S
+# C++ sources
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/libunwind.cpp
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/Unwind-EHABI.cpp
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/Unwind-seh.cpp
+
+# C sources
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/UnwindLevel1.c
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/UnwindLevel1-gcc-ext.c
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/Unwind-sjlj.c
+
+# Assembly
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/UnwindRegistersRestore.S
+LIBUNWIND_SRCS-y += $(LIBUNWIND_EXTRACTED)/src/UnwindRegistersSave.S


### PR DESCRIPTION
Updated libcxxabi to the latest upstream version; based off earlier work from @mschlumpp .
Part of a patch set w/ further PRs under [libcxx](https://github.com/unikraft/lib-libcxx/pull/27), [libcxxabi](https://github.com/unikraft/lib-libcxxabi/pull/3), [lib-compiler-rt](https://github.com/unikraft/lib-compiler-rt/pull/11) & [lib-musl](https://github.com/unikraft/lib-musl/pull/45).