### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "libunwind"
+description := "An LLVM project which provides a portable and efficient C programming interface (API) to determine the call-chain of a program."
+homepage    := "https://www.nongnu.org/libunwind/"
+license     := "Apache-2.0-with-LLVM-exception"
+version     := 14.0.6 sha256:3bbe9c23c73259fe39c045dc87d0b283236ba6e00750a226b2c2aeac4a51d86b https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.6/libunwind-14.0.6.src.tar.xz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

