### PR TITLE
Makefile.uk: Upgrade to 15.0.0

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -48,7 +48,7 @@ endif
 ################################################################################
 # Sources
 ################################################################################
-LIBUNWIND_VERSION=14.0.6
+LIBUNWIND_VERSION=15.0.0
 LIBUNWIND_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBUNWIND_VERSION)/libunwind-$(LIBUNWIND_VERSION).src.tar.xz
 LIBUNWIND_PATCHDIR=$(LIBUNWIND_BASE)/patches
 $(eval $(call fetch,libunwind,$(LIBUNWIND_URL)))


### PR DESCRIPTION
Upgrade to 15.0.0 to build compiler-rt for 15.0.0

Fixes: https://github.com/unikraft/lib-compiler-rt/issues/7
