### PR TITLE
Update to LLVM 21.1.1 

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -42,7 +42,7 @@ $(eval $(call addlib_s,libunwind,$(CONFIG_LIBUNWIND)))
 ################################################################################
 # Sources
 ################################################################################
-LIBUNWIND_VERSION=14.0.6
+LIBUNWIND_VERSION=21.1.1
 LIBUNWIND_URL=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LIBUNWIND_VERSION)/libunwind-$(LIBUNWIND_VERSION).src.tar.xz
 LIBUNWIND_PATCHDIR=$(LIBUNWIND_BASE)/patches
 $(eval $(call fetch,libunwind,$(LIBUNWIND_URL)))


### PR DESCRIPTION
Update to lib-libunwind version 21.1.1

This PR is a part of a set of PRs:

- [lib-libcxx#37](https://github.com/unikraft/lib-libcxx/pull/37)
- [lib-libcxxabi#7](https://github.com/unikraft/lib-libcxxabi/pull/7)
- [lib-libunwind#12](https://github.com/unikraft/lib-libunwind/pull/12)
- [lib-compiler-rt#21](https://github.com/unikraft/lib-compiler-rt/pull/21)

Tested with `gcc 15.2.0` and `clang 19.1.4`